### PR TITLE
PHP 8.1, bh-wp-private-uploads 0.4.x, log-viewer memory fix, notice-dismissal fix, hook signature standardization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+* Fix: out-of-memory error viewing large log files – the logs page now parses the file once, keeps only the most recent 1,000 entries, and caps each entry at 64KB (`API::parse_log_file()`), showing "Showing the most recent X of Y entries" when truncated
+* Change: parsed log entries' `context` is now the raw JSON string (decoded per-row for display) instead of a decoded `stdClass` – decoded object trees used ~10x the memory
+* Add: `API_Interface::parse_log_file( $filepath, $max_entries, $max_entry_bytes ): Parsed_Log_File` – full-file entry count and per-level counts with bounded memory
+* Add: log file size and entry counts displayed on the logs page
+* Fix: form-handler redirects used `menu_page_url()`, which returns an empty string in `admin-post.php` context
+* Fix: the download link always pointed at the most recent date rather than the displayed date
+* Fix: log levels beyond the five displayed (e.g. `critical`) no longer cause an undefined-array-key warning when counting
+
 ## 0.3.4 – 2026-07-17
 
 * Require PHP 8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Breaking: `$plugin_slug` is now the second argument (after the filtered value) of the `{$plugin_slug}_bh_wp_logger_log` and `{$plugin_slug}_bh_wp_logger_column` filters
+* Fix: the custom "logs directory is publicly accessible" warning message was hooked on a stale pre-0.4.0 bh-wp-private-uploads filter name and never applied; migrated to `bh_wp_private_uploads_url_is_public_warning`, matching this logger's own instance by plugin slug
 * Fix: dismissing any other plugin's WPTRT admin notice (e.g. bh-wp-private-uploads' "directory is publicly accessible") returned 403 – the recent-error notice's ajax gate called `check_admin_referer()` on every `wptrt_dismiss_notice` request instead of first checking the notice id
 * Fix: out-of-memory error viewing large log files – the logs page now parses the file once, keeps only the most recent 1,000 entries, and caps each entry at 64KB (`API::parse_log_file()`), showing "Showing the most recent X of Y entries" when truncated
 * Change: parsed log entries' `context` is now the raw JSON string (decoded per-row for display) instead of a decoded `stdClass` – decoded object trees used ~10x the memory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Fix: dismissing any other plugin's WPTRT admin notice (e.g. bh-wp-private-uploads' "directory is publicly accessible") returned 403 – the recent-error notice's ajax gate called `check_admin_referer()` on every `wptrt_dismiss_notice` request instead of first checking the notice id
 * Fix: out-of-memory error viewing large log files – the logs page now parses the file once, keeps only the most recent 1,000 entries, and caps each entry at 64KB (`API::parse_log_file()`), showing "Showing the most recent X of Y entries" when truncated
 * Change: parsed log entries' `context` is now the raw JSON string (decoded per-row for display) instead of a decoded `stdClass` – decoded object trees used ~10x the memory
 * Add: `API_Interface::parse_log_file( $filepath, $max_entries, $max_entry_bytes ): Parsed_Log_File` – full-file entry count and per-level counts with bounded memory

--- a/includes/admin/class-admin-notices.php
+++ b/includes/admin/class-admin-notices.php
@@ -94,18 +94,23 @@ class Admin_Notices extends Notices {
 			return;
 		}
 
-		// Check is the ajax request relevant.
+		// Check is the ajax request relevant: only register this notice when the dismissal targets it.
+		// Nonce verification is left to the WPTRT Dismiss handler ({@see \WPTRT\AdminNotices\Dismiss::ajax_maybe_dismiss_notice()});
+		// dying here on a nonce mismatch would break dismissing every other plugin's WPTRT notices,
+		// whose nonces are for their own notice ids.
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- read-only comparison to decide whether to register the notice; the Dismiss handler verifies the nonce.
 		if ( wp_doing_ajax() ) {
-			$action = "wptrt_dismiss_notice_{$this->settings->get_plugin_slug()}-recent-error";
-			if ( ! isset( $_POST['action'] )
+			if ( ! isset( $_POST['action'], $_POST['id'] )
 				|| ! is_string( $_POST['action'] )
+				|| ! is_string( $_POST['id'] )
 				|| 'wptrt_dismiss_notice' !== sanitize_key( wp_unslash( $_POST['action'] ) )
-				|| false === check_admin_referer( $action, 'nonce' ) // `false === ` doesn't do anything because it `die()`s if it fails.
+				|| sanitize_key( wp_unslash( $_POST['id'] ) ) !== "{$this->settings->get_plugin_slug()}-recent-error"
 			) {
 
 				return;
 			}
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		$error_detail_option_name = $this->get_error_detail_option_name();
 

--- a/includes/admin/class-logs-list-table.php
+++ b/includes/admin/class-logs-list-table.php
@@ -265,12 +265,13 @@ class Logs_List_Table extends WP_List_Table {
 		 * e.g. find and replace wc_order:123 with a link to the order.
 		 *
 		 * @param string $column_output
+		 * @param string $plugin_slug The plugin slug the logger is running as.
 		 * @param array{time:string, level:string, message:string, context:?string} $item The log entry row.
 		 * @param string $column_name
 		 * @param Logger_Settings_Interface $logger_settings
 		 * @param BH_WP_PSR_Logger|LoggerInterface $bh_wp_psr_logger
 		 */
-		$filtered_column_output = apply_filters( "{$plugin_slug}_bh_wp_logger_column", $column_output, $item, $column_name, $logger_settings, $bh_wp_psr_logger );
+		$filtered_column_output = apply_filters( "{$plugin_slug}_bh_wp_logger_column", $column_output, $plugin_slug, $item, $column_name, $logger_settings, $bh_wp_psr_logger );
 
 		return is_string( $filtered_column_output ) ? $filtered_column_output : $column_output; /** @phpstan-ignore function.alreadyNarrowedType */
 	}

--- a/includes/admin/class-logs-list-table.php
+++ b/includes/admin/class-logs-list-table.php
@@ -12,6 +12,7 @@
 namespace BrianHenryIE\WP_Logger\Admin;
 
 use BrianHenryIE\WP_Logger\API\BH_WP_PSR_Logger;
+use BrianHenryIE\WP_Logger\API\Parsed_Log_File;
 use BrianHenryIE\WP_Logger\API_Interface;
 use BrianHenryIE\WP_Logger\Logger_Settings_Interface;
 use DateTime;
@@ -25,6 +26,19 @@ use WP_User;
  * WordPress list table for displaying the logs.
  */
 class Logs_List_Table extends WP_List_Table {
+
+	/**
+	 * Only the most recent entries of a large log file are displayed, keeping memory use (and the
+	 * rendered page size) bounded. The full file remains available via the download link.
+	 */
+	public const MAX_DISPLAYED_ENTRIES = 1000;
+
+	/**
+	 * Each displayed entry is capped at this many bytes of log text (an entry's context can contain
+	 * enormous data, e.g. a whole email), with a truncation note appended to its message.
+	 */
+	public const MAX_ENTRY_BYTES = 65536;
+
 	/**
 	 * The logs are displayed one day at a time. The most recent day's log file, or the optionally specified date.
 	 *
@@ -33,6 +47,11 @@ class Logs_List_Table extends WP_List_Table {
 	 * @var string|null
 	 */
 	protected ?string $selected_date = null;
+
+	/**
+	 * The parsed (capped) log file for the selected date, set by {@see Logs_List_Table::prepare_items()}.
+	 */
+	protected ?Parsed_Log_File $parsed_log_file = null;
 
 	/**
 	 * Logs_Table constructor.
@@ -65,26 +84,46 @@ class Logs_List_Table extends WP_List_Table {
 	}
 
 	/**
-	 * Read the log file and parse the data.
-	 *
-	 * TODO: Move out of here. This should be a generic PSR-Log-Data class.
-	 *
-	 * @return array<array{time:string,datetime:?DateTime,level:string,message:string,context:?\stdClass}>
+	 * The path to the log file for the selected date, or the most recent log file, or null when there are none.
 	 */
-	public function get_data(): array {
+	public function get_selected_log_filepath(): ?string {
 
 		$log_files = $this->api->get_log_files();
 
 		if ( empty( $log_files ) ) {
 			// TODO: "No logs yet." message. Maybe with "current log level is:".
-			return array();
+			return null;
 		} elseif ( ! is_null( $this->selected_date ) && isset( $log_files[ $this->selected_date ] ) ) {
-			$filepath = $log_files[ $this->selected_date ];
+			return $log_files[ $this->selected_date ];
 		} else {
-			$filepath = array_pop( $log_files );
+			return array_pop( $log_files );
+		}
+	}
+
+	/**
+	 * Read the log file and parse the data.
+	 *
+	 * TODO: Move out of here. This should be a generic PSR-Log-Data class.
+	 *
+	 * @return array<array{time:string,datetime:?DateTime,level:string,message:string,context:?string}>
+	 */
+	public function get_data(): array {
+
+		$filepath = $this->get_selected_log_filepath();
+
+		if ( is_null( $filepath ) ) {
+			return array();
 		}
 
-		return $this->api->parse_log( $filepath );
+		return $this->api->parse_log_file( $filepath, self::MAX_DISPLAYED_ENTRIES, self::MAX_ENTRY_BYTES )->entries;
+	}
+
+	/**
+	 * The parsed (capped) log file, for its entry/level counts. Only set after
+	 * {@see Logs_List_Table::prepare_items()} has run.
+	 */
+	public function get_parsed_log_file(): ?Parsed_Log_File {
+		return $this->parsed_log_file;
 	}
 
 	/**
@@ -117,7 +156,14 @@ class Logs_List_Table extends WP_List_Table {
 		$hidden                = array();
 		$sortable              = array();
 		$this->_column_headers = array( $columns, $hidden, $sortable );
-		$this->items           = $this->get_data();
+
+		$filepath = $this->get_selected_log_filepath();
+
+		$this->parsed_log_file = is_null( $filepath )
+			? new Parsed_Log_File( array(), 0, array() )
+			: $this->api->parse_log_file( $filepath, self::MAX_DISPLAYED_ENTRIES, self::MAX_ENTRY_BYTES );
+
+		$this->items = $this->parsed_log_file->entries;
 	}
 
 	/**
@@ -127,7 +173,7 @@ class Logs_List_Table extends WP_List_Table {
 	 *
 	 * @used-by WP_List_Table::display_rows()
 	 *
-	 * @param array{time:string, level:string, message:string, context:array<mixed>} $item The current item.
+	 * @param array{time:string, level:string, message:string, context:?string} $item The current item.
 	 * @return void
 	 */
 	public function single_row( $item ) {
@@ -139,8 +185,8 @@ class Logs_List_Table extends WP_List_Table {
 	/**
 	 * Get the HTML for a column.
 	 *
-	 * @param array{time:string, level:string, message:string, context:array<string, mixed>} $item ...whatever type get_data returns.
-	 * @param string                                                                         $column_name The specified column.
+	 * @param array{time:string, level:string, message:string, context:?string} $item ...whatever type get_data returns.
+	 * @param string                                                            $column_name The specified column.
 	 *
 	 * @see WP_List_Table::column_default()
 	 * @see Logs_List_Table::get_data()
@@ -171,17 +217,25 @@ class Logs_List_Table extends WP_List_Table {
 				$column_output  = '<span class="logs-time">' . $column_output . '</span>';
 				break;
 			case 'context':
+				// The context is stored as its raw JSON string (decoded objects use ~10x the memory
+				// across the whole table); decode it one row at a time, only for display.
 				if ( ! empty( $item['context'] ) ) {
-					$pretty_context = wp_json_encode( $item['context'], JSON_PRETTY_PRINT );
-					// phpcs:disable WordPress.PHP.DisallowShortTernary.Found
-					$un_pretty_context = wp_json_encode( $item['context'] ) ?: '';
-					$column_output     = $pretty_context
-						? sprintf(
-							'<pre data-json="%s" class="log-context-pre">%s</pre>',
-							esc_html( $un_pretty_context ),
-							esc_html( trim( $pretty_context, "'\"" ) )
-						)
-						: esc_html( $this->get_print_r( $item['context'] ) );
+					$context = json_decode( $item['context'] );
+					if ( $context instanceof \stdClass ) {
+						unset( $context->source );
+						$pretty_context = wp_json_encode( $context, JSON_PRETTY_PRINT );
+						// phpcs:disable WordPress.PHP.DisallowShortTernary.Found
+						$un_pretty_context = wp_json_encode( $context ) ?: '';
+						$column_output     = $pretty_context
+							? sprintf(
+								'<pre data-json="%s" class="log-context-pre">%s</pre>',
+								esc_html( $un_pretty_context ),
+								esc_html( trim( $pretty_context, "'\"" ) )
+							)
+							: esc_html( $item['context'] );
+					} else {
+						$column_output = esc_html( $item['context'] );
+					}
 				}
 				break;
 			case 'message':
@@ -211,7 +265,7 @@ class Logs_List_Table extends WP_List_Table {
 		 * e.g. find and replace wc_order:123 with a link to the order.
 		 *
 		 * @param string $column_output
-		 * @param array{time:string, level:string, message:string, context:array<string,mixed>} $item The log entry row.
+		 * @param array{time:string, level:string, message:string, context:?string} $item The log entry row.
 		 * @param string $column_name
 		 * @param Logger_Settings_Interface $logger_settings
 		 * @param BH_WP_PSR_Logger|LoggerInterface $bh_wp_psr_logger
@@ -322,22 +376,5 @@ class Logs_List_Table extends WP_List_Table {
 		echo '<span class="no-items-message">';
 		echo esc_html( __( 'No items found.', 'bh-wp-logger' ) );
 		echo '</span>';
-	}
-
-	/**
-	 * Print an array to a string.
-	 *
-	 * This is probably an array whose source was reading it from a text file.
-	 * This function is used only when {@see wp_json_encode()} returns false.
-	 *
-	 * Is there a better option to print an array?
-	 *
-	 * phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_print_r
-	 *
-	 * @param array<string, mixed> $context The log context array.
-	 */
-	protected function get_print_r( array $context ): string {
-
-		return print_r( $context, true );
 	}
 }

--- a/includes/admin/class-logs-page.php
+++ b/includes/admin/class-logs-page.php
@@ -161,25 +161,37 @@ class Logs_Page {
 
 		echo '<p>Current log level: <b>' . esc_html( ucfirst( $this->settings->get_log_level() ) ) . '</b></p>';
 
+		// Parse the log file once; its entries, entry counts and level counts are all used below.
+		$logs_table->prepare_items();
+		$parsed_log_file = $logs_table->get_parsed_log_file();
+
 		// If this is in the logger's private-uploads directory, then it already should be accessible, but if it's in the wc-logs folder, it will not be.
-		$download_url = wp_nonce_url( admin_url( 'admin.php?page=' . $this->settings->get_plugin_slug() . '&date=' . $date . '&download-log=true' ), 'bh-wp-logger-download' );
+		$download_url = wp_nonce_url( admin_url( 'admin.php?page=' . $this->settings->get_plugin_slug() . '&date=' . $chosen_date . '&download-log=true' ), 'bh-wp-logger-download' );
 		$filepath     = $log_files[ $chosen_date ];
 		$filename     = basename( $filepath );
-		// TODO: Show file size here. Show number of entries.
-		echo '<p>Displaying log file at <a href="' . esc_url( $download_url ) . '" download="' . esc_attr( $filename ) . '"><code>' . esc_html( $filepath ) . '</code></a></p>';
+		$filesize     = file_exists( $filepath ) ? (int) filesize( $filepath ) : 0;
+		echo '<p>Displaying log file at <a href="' . esc_url( $download_url ) . '" download="' . esc_attr( $filename ) . '"><code>' . esc_html( $filepath ) . '</code></a> (' . esc_html( (string) size_format( $filesize ) ) . ')</p>';
+
+		if ( ! is_null( $parsed_log_file ) && $parsed_log_file->is_truncated() ) {
+			printf(
+				'<p>Showing the most recent %s of %s entries. Very large entries are shortened. Use the download link above for the full log.</p>',
+				esc_html( number_format_i18n( count( $parsed_log_file->entries ) ) ),
+				esc_html( number_format_i18n( $parsed_log_file->total_entries_count ) )
+			);
+		}
 
 		echo '<p>Display levels: ';
 
-		$log_level_counts = array(
-			LogLevel::ERROR   => 0,
-			LogLevel::WARNING => 0,
-			LogLevel::NOTICE  => 0,
-			LogLevel::INFO    => 0,
-			LogLevel::DEBUG   => 0,
+		$log_level_counts = array_merge(
+			array(
+				LogLevel::ERROR   => 0,
+				LogLevel::WARNING => 0,
+				LogLevel::NOTICE  => 0,
+				LogLevel::INFO    => 0,
+				LogLevel::DEBUG   => 0,
+			),
+			is_null( $parsed_log_file ) ? array() : $parsed_log_file->level_counts
 		);
-		foreach ( $logs_table->get_data() as $datum ) {
-			++$log_level_counts[ strtolower( $datum['level'] ) ];
-		}
 
 		$checkboxes_first = true;
 		foreach ( $log_level_counts as $log_level => $log_level_count ) {
@@ -206,7 +218,6 @@ class Logs_Page {
 
 		// TODO: Add an action here for other plugins to add controls.
 
-		$logs_table->prepare_items();
 		$logs_table->display();
 
 		echo '</div>';

--- a/includes/api/class-api.php
+++ b/includes/api/class-api.php
@@ -288,6 +288,8 @@ class API implements API_Interface {
 				case isset( $frame['file'] ) && false !== stripos( $frame['file'], 'bh-wp-logger/includes' ):
 				case isset( $frame['file'] ) && false !== stripos( $frame['file'], 'psr/log/Psr/Log/' ):
 				case isset( $frame['file'] ) && str_contains( $frame['file'], 'php-http/logger-plugin' ):
+				case isset( $frame['file'] ) && 'LoggerTrait.php' === basename( $frame['file'] ):
+				case isset( $frame['class'] ) && 'BH_WP_PSR_Logger' === array_reverse( explode( '\\', $frame['class'] ) )[0]:
 					return true;
 				default:
 					return false;

--- a/includes/api/class-api.php
+++ b/includes/api/class-api.php
@@ -514,21 +514,46 @@ class API implements API_Interface {
 	 * Given the path to a log file, this returns an array of arrays – an array of log entries, each of which is an
 	 * array containing the time, level, message and context.
 	 *
+	 * NB: This loads every entry, at full size, into memory. For UI display prefer
+	 * {@see API::parse_log_file()}, whose limits keep memory use bounded on large files.
+	 *
 	 * @used-by API::get_last_log_time()
-	 * @used-by Logs_List_Table::get_data()
 	 *
 	 * @param string $filepath Path to the log file to read.
 	 *
-	 * @return array<array{time:string,datetime:DateTime|null,level:string,message:string,context:stdClass|null}>
+	 * @return array<array{time:string,datetime:DateTime|null,level:string,message:string,context:string|null}>
 	 */
 	public function parse_log( string $filepath ): array {
+		return $this->parse_log_file( $filepath )->entries;
+	}
+
+	/**
+	 * Appended in place of an entry's remaining lines when it exceeds the max-entry-bytes limit.
+	 */
+	protected const LOG_ENTRY_TRUNCATED_MESSAGE = '… [log entry truncated for display – download the log file to view it in full]';
+
+	/**
+	 * Parse a log file into entries, with limits so memory use stays bounded on large files.
+	 *
+	 * The whole file is always scanned (one line at a time), so the total entry count and per-level
+	 * counts cover the full file; the limits only cap what is kept in memory and returned.
+	 *
+	 * @used-by Logs_List_Table::prepare_items()
+	 *
+	 * @param string $filepath        Path to the log file to read.
+	 * @param ?int   $max_entries     Keep only the most recent N entries (null = no limit).
+	 * @param ?int   $max_entry_bytes Cap each entry at this many bytes of log text, appending a
+	 *                                truncation note to its message (null = no limit). A truncated
+	 *                                entry's JSON context is cut short, so its context parses to null.
+	 */
+	public function parse_log_file( string $filepath, ?int $max_entries = null, ?int $max_entry_bytes = null ): Parsed_Log_File {
 
 		// The file is read one line at a time to avoid loading a potentially large log into memory.
 		$file_handle = fopen( $filepath, 'rb' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 
 		if ( false === $file_handle ) {
 			// Failed to open the file.
-			return array();
+			return new Parsed_Log_File( array(), 0, array() );
 		}
 
 		if ( $this->logger instanceof WC_PSR_Logger ) {
@@ -539,7 +564,33 @@ class API implements API_Interface {
 
 		$time_pattern = '/^(?P<time>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.{1}\d{2}:\d{2})/i';
 
-		$entries = array();
+		/**
+		 * The kept entries. When $max_entries is set, this is used as a ring buffer (index
+		 * $total_entries % $max_entries) so only the most recent entries are retained, and is
+		 * rotated back into chronological order after the file has been read.
+		 */
+		$entries       = array();
+		$total_entries = 0;
+		$level_counts  = array();
+
+		// Parse one entry's accumulated lines: count it, and keep it (in the ring buffer when capped).
+		$record_entry = function ( array $lines ) use ( &$entries, &$total_entries, &$level_counts, $pattern, $max_entries ): void {
+			/** @var string[] $lines */
+			$entry = $this->log_lines_to_entry( $lines, $pattern );
+			if ( is_null( $entry ) ) {
+				return;
+			}
+
+			$level                  = strtolower( $entry['level'] );
+			$level_counts[ $level ] = ( $level_counts[ $level ] ?? 0 ) + 1;
+
+			if ( is_null( $max_entries ) ) {
+				$entries[] = $entry;
+			} else {
+				$entries[ $total_entries % $max_entries ] = $entry;
+			}
+			++$total_entries;
+		};
 
 		/**
 		 * Each log entry begins with a line starting with a timestamp ($time_pattern). Read the file
@@ -547,7 +598,9 @@ class API implements API_Interface {
 		 * line (or the end of the file), then hand the collected lines off to be parsed into a single
 		 * entry. Lines before the first timestamp do not belong to any entry and are discarded.
 		 */
-		$entry_lines = array();
+		$entry_lines        = array();
+		$entry_bytes        = 0;
+		$entry_is_truncated = false;
 
 		while ( false !== ( $line = fgets( $file_handle ) ) ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 
@@ -556,27 +609,44 @@ class API implements API_Interface {
 			if ( 1 === preg_match( $time_pattern, $line ) ) {
 				// A new entry starts on this line; parse the entry that just ended.
 				if ( count( $entry_lines ) > 0 ) {
-					$entry = $this->log_lines_to_entry( $entry_lines, $pattern );
-					if ( ! is_null( $entry ) ) {
-						$entries[] = $entry;
-					}
+					$record_entry( $entry_lines );
 				}
-				$entry_lines = array( $line );
+				// An entry can be a single enormous line (e.g. an inline JSON context); cap it too.
+				$entry_is_truncated = ! is_null( $max_entry_bytes ) && strlen( $line ) > $max_entry_bytes;
+				if ( $entry_is_truncated ) {
+					$entry_lines = array( substr( $line, 0, $max_entry_bytes ), self::LOG_ENTRY_TRUNCATED_MESSAGE );
+				} else {
+					$entry_lines = array( $line );
+				}
+				$entry_bytes = strlen( $entry_lines[0] );
 			} elseif ( count( $entry_lines ) > 0 ) {
 				// A continuation line, e.g. a stack trace or multi-line JSON context.
+				if ( ! is_null( $max_entry_bytes ) && $entry_bytes + strlen( $line ) > $max_entry_bytes ) {
+					if ( ! $entry_is_truncated ) {
+						$entry_lines[]      = self::LOG_ENTRY_TRUNCATED_MESSAGE;
+						$entry_is_truncated = true;
+					}
+					continue;
+				}
 				$entry_lines[] = $line;
+				$entry_bytes  += strlen( $line );
 			}
 		}
 
 		// Parse the final entry.
 		if ( count( $entry_lines ) > 0 ) {
-			$entry = $this->log_lines_to_entry( $entry_lines, $pattern );
-			if ( ! is_null( $entry ) ) {
-				$entries[] = $entry;
-			}
+			$record_entry( $entry_lines );
 		}
 
-		return $entries;
+		fclose( $file_handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+
+		// Rotate the ring buffer back into chronological order.
+		if ( ! is_null( $max_entries ) && $total_entries > $max_entries ) {
+			$offset  = $total_entries % $max_entries;
+			$entries = array_merge( array_slice( $entries, $offset ), array_slice( $entries, 0, $offset ) );
+		}
+
+		return new Parsed_Log_File( array_values( $entries ), $total_entries, $level_counts );
 	}
 
 	/**
@@ -587,12 +657,16 @@ class API implements API_Interface {
 	 * To recover the context: if the entry ends with `}`, seek in reverse for the line that opens the JSON
 	 * object, decode from there to the end, and treat the lines before it as the remainder of the message.
 	 *
-	 * @used-by API::parse_log()
+	 * The context is returned as its (validated) raw JSON string, NOT decoded: a decoded object tree
+	 * costs roughly an order of magnitude more memory than the JSON text, which matters when many
+	 * entries are held for display. Consumers decode it as needed, one entry at a time.
+	 *
+	 * @used-by API::parse_log_file()
 	 *
 	 * @param string[] $lines   The lines of a single log entry, with newlines already stripped.
 	 * @param string   $pattern The regex used to parse the first line into time/level/message (and, for WooCommerce, an inline context).
 	 *
-	 * @return ?array{time:string,datetime:DateTime|null,level:string,message:string,context:stdClass|null}
+	 * @return ?array{time:string,datetime:DateTime|null,level:string,message:string,context:string|null}
 	 */
 	protected function log_lines_to_entry( array $lines, string $pattern ): ?array {
 
@@ -614,8 +688,9 @@ class API implements API_Interface {
 		if ( isset( $line_one['context'] ) ) {
 
 			// WooCommerce logs the context inline on the first line, after "CONTEXT:".
-			$context = json_decode( $line_one['context'] );
-
+			if ( json_decode( $line_one['context'] ) instanceof stdClass ) {
+				$context = $line_one['context'];
+			}
 		} else {
 
 			$context_lines = array_slice( $lines, 1 );
@@ -635,9 +710,13 @@ class API implements API_Interface {
 
 					// The context can contain unescaped literal newlines inside string values (e.g. a
 					// stack trace), which json_decode rejects; escape them and try again.
-					$context = json_decode( $candidate ) ?? json_decode( str_replace( "\n", '\n', $candidate ) );
+					if ( is_null( json_decode( $candidate ) ) ) {
+						$candidate = str_replace( "\n", '\n', $candidate );
+					}
 
-					if ( ! is_null( $context ) ) {
+					if ( json_decode( $candidate ) instanceof stdClass ) {
+						$context = $candidate;
+
 						// Any lines before the JSON object are a continuation of the message.
 						$message_lines = array_slice( $context_lines, 0, $i );
 						if ( count( $message_lines ) > 0 ) {
@@ -651,18 +730,13 @@ class API implements API_Interface {
 			// Fallback: any remaining lines that are not themselves valid JSON are message text.
 			if ( is_null( $context ) ) {
 				foreach ( $context_lines as $context_line ) {
-					$decoded = json_decode( $context_line );
-					if ( is_null( $decoded ) ) {
-						$message .= "\n" . $context_line;
+					if ( json_decode( $context_line ) instanceof stdClass ) {
+						$context = $context_line;
 					} else {
-						$context = $decoded;
+						$message .= "\n" . $context_line;
 					}
 				}
 			}
-		}
-
-		if ( $context instanceof stdClass && isset( $context->source ) ) {
-			unset( $context->source );
 		}
 
 		return array(
@@ -670,7 +744,7 @@ class API implements API_Interface {
 			'datetime' => $datetime,
 			'level'    => $level,
 			'message'  => $message,
-			'context'  => $context instanceof stdClass ? $context : null,
+			'context'  => $context,
 		);
 	}
 }

--- a/includes/api/class-bh-wp-psr-logger.php
+++ b/includes/api/class-bh-wp-psr-logger.php
@@ -180,10 +180,11 @@ class BH_WP_PSR_Logger extends API implements LoggerInterface {
 			 * Return null to cancel logging this message.
 			 *
 			 * @param array{level:string,message:string,context:array} $log_data
+			 * @param string $plugin_slug The plugin slug the logger is running as.
 			 * @param Logger_Settings_Interface $settings
 			 * @param BH_WP_PSR_Logger $bh_wp_psr_logger
 			 */
-			$log_data = apply_filters( $this->settings->get_plugin_slug() . '_bh_wp_logger_log', $log_data, $settings, $bh_wp_psr_logger );
+			$log_data = apply_filters( $this->settings->get_plugin_slug() . '_bh_wp_logger_log', $log_data, $this->settings->get_plugin_slug(), $settings, $bh_wp_psr_logger );
 
 			if ( empty( $log_data ) ) {
 				return;

--- a/includes/api/class-parsed-log-file.php
+++ b/includes/api/class-parsed-log-file.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * The result of parsing a log file: its entries (possibly capped) and summary counts.
+ *
+ * @package brianhenryie/bh-wp-logger
+ */
+
+namespace BrianHenryIE\WP_Logger\API;
+
+use DateTime;
+
+/**
+ * Value object returned by {@see API::parse_log_file()}.
+ */
+class Parsed_Log_File {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array<array{time:string,datetime:DateTime|null,level:string,message:string,context:string|null}> $entries The parsed log entries, oldest first. When a max-entries limit was set, only the most recent entries are included.
+	 * @param int                                                                                              $total_entries_count The number of entries in the whole file, including any omitted from $entries.
+	 * @param array<string,int>                                                                                $level_counts        The number of entries in the whole file at each log level, keyed by lowercase level name.
+	 */
+	public function __construct(
+		public readonly array $entries,
+		public readonly int $total_entries_count,
+		public readonly array $level_counts,
+	) {
+	}
+
+	/**
+	 * Were entries omitted due to the max-entries limit?
+	 */
+	public function is_truncated(): bool {
+		return count( $this->entries ) < $this->total_entries_count;
+	}
+}

--- a/includes/interface-api-interface.php
+++ b/includes/interface-api-interface.php
@@ -8,6 +8,7 @@
 namespace BrianHenryIE\WP_Logger;
 
 use BrianHenryIE\WP_Logger\Admin\AJAX;
+use BrianHenryIE\WP_Logger\API\Parsed_Log_File;
 use BrianHenryIE\WP_Logger\Admin\Logs_List_Table;
 use BrianHenryIE\WP_Logger\Admin\Logs_Page;
 use BrianHenryIE\WP_Logger\Admin\Plugins_Page;
@@ -146,11 +147,26 @@ interface API_Interface {
 	 * Given the path to a log text file, parse its lines into an array of individual log entries parsed into
 	 * time, level, message, and context.
 	 *
-	 * @used-by Logs_List_Table::get_data()
+	 * NB: This loads every entry, at full size, into memory. For UI display prefer
+	 * {@see API_Interface::parse_log_file()}, whose limits keep memory use bounded on large files.
 	 *
 	 * @param string $filepath The full path to the log file.
 	 *
-	 * @return array<array{time:string,datetime:DateTime|null,level:string,message:string,context:stdClass|null}>
+	 * @return array<array{time:string,datetime:DateTime|null,level:string,message:string,context:string|null}>
 	 */
 	public function parse_log( string $filepath ): array;
+
+	/**
+	 * Parse a log file into entries, with limits so memory use stays bounded on large files.
+	 *
+	 * The whole file is always scanned, so the total entry count and per-level counts cover the full
+	 * file; the limits only cap what is kept in memory and returned.
+	 *
+	 * @used-by Logs_List_Table::prepare_items()
+	 *
+	 * @param string $filepath        The full path to the log file.
+	 * @param ?int   $max_entries     Keep only the most recent N entries (null = no limit).
+	 * @param ?int   $max_entry_bytes Cap each entry at this many bytes of log text, appending a truncation note to its message (null = no limit).
+	 */
+	public function parse_log_file( string $filepath, ?int $max_entries = null, ?int $max_entry_bytes = null ): Parsed_Log_File;
 }

--- a/includes/private-uploads/class-url-is-public.php
+++ b/includes/private-uploads/class-url-is-public.php
@@ -12,6 +12,8 @@
 
 namespace BrianHenryIE\WP_Logger\Private_Uploads;
 
+use BrianHenryIE\WP_Logger\Logger_Settings_Interface;
+
 /**
  * Filter the bh-wp-private-uploads admin-notice that is shown when the logs url is public.
  *
@@ -20,17 +22,38 @@ namespace BrianHenryIE\WP_Logger\Private_Uploads;
 class URL_Is_Public {
 
 	/**
+	 * Constructor.
+	 *
+	 * @param Logger_Settings_Interface $settings The logger settings, whose plugin slug identifies this logger's private-uploads instance.
+	 */
+	public function __construct(
+		protected Logger_Settings_Interface $settings,
+	) {
+	}
+
+	/**
 	 * Change the warning message to say:
 	 * "The logs directory is, and should not be, publicly accessible at the URL: %s. Please update your webserver configuration to block access to that folder."
 	 *
-	 * @hooked bh_wp_private_uploads_url_is_public_warning_{$this->settings->get_plugin_slug()}._logger
+	 * The filter fires for every private-uploads instance, so the message is only changed for this
+	 * logger's own instance (whose plugin slug is the logger's plugin slug suffixed with `_logger`,
+	 * {@see \BrianHenryIE\WP_Logger\Logger}).
 	 *
-	 * @param string $_message The default message. We will override this, but it is a positional argument in the filter.
-	 * @param string $url The publicly accessible URL.
+	 * @hooked bh_wp_private_uploads_url_is_public_warning
+	 * @see \BrianHenryIE\WP_Logger\WP_Includes\Plugin_Logger_Actions::add_private_uploads_hooks()
+	 *
+	 * @param string $message        The default message. Overridden for this logger's own instance.
+	 * @param string $plugin_slug    The plugin slug of the private uploads instance whose URL is public.
+	 * @param string $post_type_name The post type name of the private uploads instance whose URL is public.
+	 * @param string $url            The publicly accessible URL.
 	 *
 	 * @return string
 	 */
-	public function change_warning_message( string $_message, string $url ): string {
+	public function change_warning_message( string $message, string $plugin_slug, string $post_type_name, string $url ): string {
+
+		if ( $this->settings->get_plugin_slug() . '_logger' !== $plugin_slug ) {
+			return $message;
+		}
 
 		return sprintf(
 			/* translators: %s: The URL where the log files are accessible. */

--- a/includes/wp-includes/class-plugin-logger-actions.php
+++ b/includes/wp-includes/class-plugin-logger-actions.php
@@ -179,9 +179,9 @@ class Plugin_Logger_Actions {
 	 */
 	protected function add_private_uploads_hooks(): void {
 
-		$url_is_public = new URL_Is_Public();
+		$url_is_public = new URL_Is_Public( $this->settings );
 
-		add_filter( "bh_wp_private_uploads_url_is_public_warning_{$this->settings->get_plugin_slug()}_logger", array( $url_is_public, 'change_warning_message' ), 10, 2 );
+		add_filter( 'bh_wp_private_uploads_url_is_public_warning', array( $url_is_public, 'change_warning_message' ), 10, 4 );
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "GPL-2.0+",
       "devDependencies": {
-        "@wordpress/env": "^11.0.0"
+        "@wordpress/env": "^11.3.0"
       }
     },
     "node_modules/@inquirer/ansi": {
@@ -483,9 +483,9 @@
       "license": "MIT"
     },
     "node_modules/@nodable/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
       "dev": true,
       "funding": [
         {
@@ -1056,13 +1056,13 @@
       "license": "MIT"
     },
     "node_modules/@php-wasm/cli-util": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.38.tgz",
-      "integrity": "sha512-dbGKLVejsW4IsrqcZfRlrCawt/Xaw6/heGDElzvNIFOo9dKq3O+TEGTWe4uTr9E0qCRWA6cReAh0IKnuFApRlA==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.45.tgz",
+      "integrity": "sha512-+ht22B6KPUsn5ORtApE5xYq+uIb7/Qv/NSOxYgNGSWf3O1rpxkbOMeCxtE7H3dvazJIlSF+/nsVHpHkcTZGOpA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/util": "3.1.38",
+        "@php-wasm/util": "3.1.45",
         "fast-xml-parser": "^5.8.0",
         "jsonc-parser": "3.3.1"
       },
@@ -1072,9 +1072,9 @@
       }
     },
     "node_modules/@php-wasm/logger": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.38.tgz",
-      "integrity": "sha512-DSLl/gvYtJl+gDubY95PPdks/4MvDd8wJlXE3PPkCIbc7dm+g3V5wXHTSl4cZzfSNdytBmRwmZkdCpe5Fu3hKw==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.45.tgz",
+      "integrity": "sha512-FYWGxaRZTM+aiRQ6/LlnFAdsixJ7VWQpM8Fe/61yWgpBamb1w3NEDRhYVR5DNjYWJVI5ha6pVxIsHtw018iA7g==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -1083,24 +1083,24 @@
       }
     },
     "node_modules/@php-wasm/node": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.38.tgz",
-      "integrity": "sha512-dRl6LHPN42/TSFX25tq4WgKRq55YnIUjfDOi9TlywVzMw4dMY2/aAIDJX/dwN3Sgn9pc9ekgJqXivzDlnLDVWQ==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.45.tgz",
+      "integrity": "sha512-IFnGdNsQ0g8RwpFzg3gAt8VckFwshQ7g2Izwt+i+wi2Rtnj54DcPZpfMwliiq+c1XU1//jtXHBdczbwR75yW7A==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/cli-util": "3.1.38",
-        "@php-wasm/logger": "3.1.38",
-        "@php-wasm/node-5-2": "3.1.38",
-        "@php-wasm/node-7-4": "3.1.38",
-        "@php-wasm/node-8-0": "3.1.38",
-        "@php-wasm/node-8-1": "3.1.38",
-        "@php-wasm/node-8-2": "3.1.38",
-        "@php-wasm/node-8-3": "3.1.38",
-        "@php-wasm/node-8-4": "3.1.38",
-        "@php-wasm/node-8-5": "3.1.38",
-        "@php-wasm/universal": "3.1.38",
-        "@php-wasm/util": "3.1.38",
+        "@php-wasm/cli-util": "3.1.45",
+        "@php-wasm/logger": "3.1.45",
+        "@php-wasm/node-5-2": "3.1.45",
+        "@php-wasm/node-7-4": "3.1.45",
+        "@php-wasm/node-8-0": "3.1.45",
+        "@php-wasm/node-8-1": "3.1.45",
+        "@php-wasm/node-8-2": "3.1.45",
+        "@php-wasm/node-8-3": "3.1.45",
+        "@php-wasm/node-8-4": "3.1.45",
+        "@php-wasm/node-8-5": "3.1.45",
+        "@php-wasm/universal": "3.1.45",
+        "@php-wasm/util": "3.1.45",
         "fs-ext-extra-prebuilt": "2.2.7",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.21.0"
@@ -1111,13 +1111,13 @@
       }
     },
     "node_modules/@php-wasm/node-5-2": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-5-2/-/node-5-2-3.1.38.tgz",
-      "integrity": "sha512-s4Ly1znifuhI+esoUdsjWQrf0TcC2Jd7HQkmN7sDSn0xCd36uxRAdZ0w04t4NqWHjQUFvWT1XpBDbEQh779fOw==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-5-2/-/node-5-2-3.1.45.tgz",
+      "integrity": "sha512-mKYOI8/eWE7Gu9wOOwtcxGrhOfCfGlIqT3Jr1RK0qCsZ/GkiW2/EalsNC5wSWbaL9qdh4JUbXUoF7mE3dc+KRQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.38",
+        "@php-wasm/universal": "3.1.45",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1126,13 +1126,13 @@
       }
     },
     "node_modules/@php-wasm/node-7-4": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.38.tgz",
-      "integrity": "sha512-/7LibshPqhZWXgnhKlbqg0xTyuTvZV62mGhr4imstomJepdoL5DcpyX/+z6UKkCB0YQDMAak8JK/2wwBwFoEdw==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.45.tgz",
+      "integrity": "sha512-3+VgXIL4y4Acb/OyNQAsIfz5I5GYlFmjw4M8l2Xx8TNBrixuOEO5vHmMoTssynZlmjoTLxBBzL2SaRHoubwi6g==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.38",
+        "@php-wasm/universal": "3.1.45",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1141,13 +1141,13 @@
       }
     },
     "node_modules/@php-wasm/node-8-0": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.38.tgz",
-      "integrity": "sha512-Lzyqk1DWf/fjarX9IidJ6oHKI00htKgcnuPFwwMYUvxdzWTgWa2WhJuwprWXtQH4sAOjq0Kd7Q1wXFhN2YTFpA==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.45.tgz",
+      "integrity": "sha512-6yJaW+mxgBWAy80IYRU41bh1LH4WsuDgqEWiHSumJcKOcNljSedUbm+YuLTY+Pnsov7u5yzkaBskslxGXcOlIQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.38",
+        "@php-wasm/universal": "3.1.45",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1156,13 +1156,13 @@
       }
     },
     "node_modules/@php-wasm/node-8-1": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.38.tgz",
-      "integrity": "sha512-9b75i2uJwD0ApFJ7+XwV1+fHNMoxZJNFyNTNhleezQJX2XsIpRskPRiW/HuUEYfQmfrsfVUZlcUKdtjmWoG+Ww==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.45.tgz",
+      "integrity": "sha512-/5haLrmCySu40aDGtVAOukDBNYzCJ0JTXslXs36Rh8P9V2nlctVGO+Kp1m/74yCtdoJrZsRrBnVqKBCliVQjdg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.38",
+        "@php-wasm/universal": "3.1.45",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1171,13 +1171,13 @@
       }
     },
     "node_modules/@php-wasm/node-8-2": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.38.tgz",
-      "integrity": "sha512-93VX1v+C48V/UZQ+avGncKNON3dxZJGFMj2vlMkQHF4982tbaQM+UcpkifMeSdt5BlArsT5AokR5ll+wUlK+0Q==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.45.tgz",
+      "integrity": "sha512-fGsSHw6OTnNyjr6k87OqV8SYqRZlDrWYVSXFkOywXUbBvyAYeuttxHffYC4VoRZdRz+Ygu+2k2aPE06jpTTBFw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.38",
+        "@php-wasm/universal": "3.1.45",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1186,13 +1186,13 @@
       }
     },
     "node_modules/@php-wasm/node-8-3": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.38.tgz",
-      "integrity": "sha512-klWqS+ZTjNibBo6INWC8A4PaHkGgZg0ubaZKGf5yMsVSjdYP1i9dJGSGy+hEhXKPHTHhtM0qKwTkbjjrvCQjBQ==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.45.tgz",
+      "integrity": "sha512-dq22w7k6zxSgRKEjFej2k2etHpWA/f6UZFQCwi0qPFTejlVRfGqJoY+6gwtF4PCCGXGD7J36XyRuSFuZz833MA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.38",
+        "@php-wasm/universal": "3.1.45",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1201,13 +1201,13 @@
       }
     },
     "node_modules/@php-wasm/node-8-4": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.38.tgz",
-      "integrity": "sha512-mg3fm0HMKY7VTEl8mFITqGkSlI4Xp8/XQ/9P9Wc/Qn1ktkjA2r110vAZl8bXT7mry2qNUXXixAqPj9zQKrFf7g==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.45.tgz",
+      "integrity": "sha512-QElunKrFEpVa11Fdr6Afmw/gI/bCf5rxzAuXLBYfgghJP2w8sTT0M1ku1pocPEvMGeONbQgvHA06sDdKXhHEMA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.38",
+        "@php-wasm/universal": "3.1.45",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1216,13 +1216,13 @@
       }
     },
     "node_modules/@php-wasm/node-8-5": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.38.tgz",
-      "integrity": "sha512-kDA3Lm7rvx/HuqO32BlmV2XjtMCKgDiPrB42Kp8ZhOrNhb0gzhoMBEvDT4dppUq0GiLp39fP818o3fbKIiJZWw==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.45.tgz",
+      "integrity": "sha512-FeKtaRMZorN1uRFbC6DILfv+Y9ImEMLjcpNVyT7zZ4WHPEf1yN0Q0Jo8VH9NNwCmkmiDAQN2gAIn3nKL8vsz+g==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.38",
+        "@php-wasm/universal": "3.1.45",
         "wasm-feature-detect": "1.8.0"
       },
       "engines": {
@@ -1231,13 +1231,13 @@
       }
     },
     "node_modules/@php-wasm/progress": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.38.tgz",
-      "integrity": "sha512-cmmbe7ZgIN0kG2Tbp7Nh0gYKVpPygFJMu8B+fOjdS/lfm5zwJqkkIAn6fdcjYL2DO9s3+IGWjhdhqGtlzY3L+g==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.45.tgz",
+      "integrity": "sha512-rc/I9MSoqAPLRmrgArpWMrSq6s7R16ulrMjG3Ti5T4hfu+j2oxfBCHbrwzR57ITsgecjKZ+G9j/w+saQj9cgpQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.38"
+        "@php-wasm/logger": "3.1.45"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1245,9 +1245,9 @@
       }
     },
     "node_modules/@php-wasm/scopes": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.38.tgz",
-      "integrity": "sha512-rbrsC5X3WVkD7K9E86wnRr4qhUU8AzycJxafJdSsh/LPjeRvxQpu8xhIMxmtFgfuMBzpWRQbsFQmKfSCgHMcAA==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.45.tgz",
+      "integrity": "sha512-7efo3IvGLMOcUuywB40avWz1c6c7YurmRW/hM44iPlhr72x9Wpth9eHjI+Gsn+qFISmUqjW+G2KHx9BD7BTQBA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -1256,26 +1256,26 @@
       }
     },
     "node_modules/@php-wasm/stream-compression": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.38.tgz",
-      "integrity": "sha512-8YUS+1buRqhkKBfqpPcZYI59wOYaOHiMzryZMpkdJVA4ELFkWR9NfLxJopGJbGGB/qGg7V5GFKFV6EP5RxbdPw==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.45.tgz",
+      "integrity": "sha512-zLU1AGNEg1tuwm93LHrL8OcV24LyNglTg/CXV5CVZiMPpg1wfIDHJy11qqjZM8iCIJk87qYQhkKOjTnGinAVDg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/util": "3.1.38"
+        "@php-wasm/util": "3.1.45"
       }
     },
     "node_modules/@php-wasm/universal": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.38.tgz",
-      "integrity": "sha512-H2op/4rZb5XYit54Z9jHULQwQIDp11Cv2ubp8Iv0pNkPBb5acW9g5/R+slB6tP6GW2Z0PyVxoVjzc3fab2v0Yw==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.45.tgz",
+      "integrity": "sha512-3x0TWQg6NEeO+M/oPA3rAP0hJB2gnsqwkb2sUipz0RQQXRkWEJjdrT20UVmGN/dXILDWeQg/VGxZhCktoWZGkA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.38",
-        "@php-wasm/progress": "3.1.38",
-        "@php-wasm/stream-compression": "3.1.38",
-        "@php-wasm/util": "3.1.38",
+        "@php-wasm/logger": "3.1.45",
+        "@php-wasm/progress": "3.1.45",
+        "@php-wasm/stream-compression": "3.1.45",
+        "@php-wasm/util": "3.1.45",
         "ini": "4.1.2"
       },
       "engines": {
@@ -1284,9 +1284,9 @@
       }
     },
     "node_modules/@php-wasm/util": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.38.tgz",
-      "integrity": "sha512-afqgA8gBzISH6FGifXWQPcZ7WDLXxvEaSTFnc7uWPtDgsmhl0fGE0vIRMmrfIgR/7EvrdR/9d4wJXs8LcpX5uA==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.45.tgz",
+      "integrity": "sha512-czXqXd2NJWkapV/zTr3WPSPdcgyI5KN7xSUusYpgkfljSovfvHOKKrTMQtbfPXRa9+MD8LmPQt+XStKPRp76Tg==",
       "dev": true,
       "engines": {
         "node": ">=20.10.0",
@@ -1294,14 +1294,14 @@
       }
     },
     "node_modules/@php-wasm/web-service-worker": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.38.tgz",
-      "integrity": "sha512-7ghdF2YfrRnbKUpl8/KYkwgp4qkNBz6hubfXjMiHTmfEoPG/ZPEMxAavdJxJSAOfW1GXpdzUTVviu2B+g/UTLg==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.45.tgz",
+      "integrity": "sha512-L8spIluLVlaOZ8CnNPfJ5IEM/e1YouQ9kB8GJL+NVm27Pci/pxBE5Hi7nsmau/oQJ6JTA6rXMuDh3wyicFU0Xg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/scopes": "3.1.38",
-        "@php-wasm/universal": "3.1.38"
+        "@php-wasm/scopes": "3.1.45",
+        "@php-wasm/universal": "3.1.45"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1309,14 +1309,14 @@
       }
     },
     "node_modules/@php-wasm/xdebug-bridge": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.1.38.tgz",
-      "integrity": "sha512-yJBZG8TmzYEMs5BPnadJz0cJ35biwPcvxuwcz+kcc5Rp6DioRZ64MFWKT2hsQgMGvLQskBfKCyC/8PNDRuqU6g==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.1.45.tgz",
+      "integrity": "sha512-InIWrSl9ULFEyIYbIK+uh2TK3N7VhQuycx3tRSaRY7YNpUGS2xxfNSt4BeJgBgUNmslKsQojSjCcmvumJW1mgg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.38",
-        "@php-wasm/universal": "3.1.38",
+        "@php-wasm/logger": "3.1.45",
+        "@php-wasm/universal": "3.1.45",
         "ws": "8.21.0",
         "xml2js": "0.6.2",
         "yargs": "17.7.2"
@@ -1327,6 +1327,47 @@
       "engines": {
         "node": ">=20.10.0",
         "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/xdebug-bridge/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@php-wasm/xdebug-bridge/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@php-wasm/xdebug-bridge/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1446,13 +1487,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/responselike": {
@@ -1466,24 +1507,24 @@
       }
     },
     "node_modules/@wordpress/env": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-11.8.0.tgz",
-      "integrity": "sha512-VPsP81ID/XAuZn1DHDyApIeSx88WyKwwFhwc2u0RkGWzbYFB3xnkMBqx7ipFBS0TD79PLY5tcEgjMPU2R077pg==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-11.11.0.tgz",
+      "integrity": "sha512-E4Riaan41uAcm70FFTD78Z1qtObQJwRlIyXdsr04X+mrg8XkBuHSqM1iSvgqnOpVzUuF9EYANYKF0CTm9tKW5w==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@inquirer/prompts": "^7.2.0",
         "@wp-playground/cli": "^3.0.48",
-        "chalk": "^4.0.0",
+        "adm-zip": "^0.5.9",
+        "chalk": "^4.1.1",
         "copy-dir": "^1.3.0",
         "cross-spawn": "^7.0.6",
         "docker-compose": "^0.24.3",
-        "extract-zip": "^1.6.7",
         "got": "^11.8.5",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "^3.15.0",
         "ora": "^4.0.2",
         "rimraf": "^5.0.10",
-        "simple-git": "^3.5.0",
+        "simple-git": "^3.24.0",
         "yargs": "^17.3.0"
       },
       "bin": {
@@ -1495,20 +1536,20 @@
       }
     },
     "node_modules/@wp-playground/blueprints": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.38.tgz",
-      "integrity": "sha512-OdmiDVK2EEzsohrf4xJxNYKcuubYB23t+bcwPUBQpzcVILiidLqljmRghrkGNex5ky58KTnuLn9gubKGWWmGjg==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.45.tgz",
+      "integrity": "sha512-q7jEN5w6dgwpzk26mkSGLLPEsTQsRfily0wPolAwueyhq2bnY7Nil7r1k+JHTR2XpTSg3Y3rFyp3j1biOpbsDA==",
       "dev": true,
       "dependencies": {
-        "@php-wasm/logger": "3.1.38",
-        "@php-wasm/progress": "3.1.38",
-        "@php-wasm/stream-compression": "3.1.38",
-        "@php-wasm/universal": "3.1.38",
-        "@php-wasm/util": "3.1.38",
-        "@php-wasm/web-service-worker": "3.1.38",
-        "@wp-playground/common": "3.1.38",
-        "@wp-playground/storage": "3.1.38",
-        "@wp-playground/wordpress": "3.1.38",
+        "@php-wasm/logger": "3.1.45",
+        "@php-wasm/progress": "3.1.45",
+        "@php-wasm/stream-compression": "3.1.45",
+        "@php-wasm/universal": "3.1.45",
+        "@php-wasm/util": "3.1.45",
+        "@php-wasm/web-service-worker": "3.1.45",
+        "@wp-playground/common": "3.1.45",
+        "@wp-playground/storage": "3.1.45",
+        "@wp-playground/wordpress": "3.1.45",
         "ajv": "8.18.0"
       },
       "engines": {
@@ -1517,24 +1558,24 @@
       }
     },
     "node_modules/@wp-playground/cli": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-3.1.38.tgz",
-      "integrity": "sha512-xvTQ053ToDa+jd47Bxmuambzfx4lm0ILXDXGoxkd62oaMsyB8+EczfwZhLLECaCDwVzlCM9XO0mOWEJ8YNC9KQ==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-3.1.45.tgz",
+      "integrity": "sha512-9cSDXOJoSdZSVrNBOraLlkiBMnvxy0EyaUrkr/8kBkNhWgNv2WhoPxMY25B0eh8nocH2mLVFHg9s4thuFghhug==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/cli-util": "3.1.38",
-        "@php-wasm/logger": "3.1.38",
-        "@php-wasm/node": "3.1.38",
-        "@php-wasm/progress": "3.1.38",
-        "@php-wasm/universal": "3.1.38",
-        "@php-wasm/util": "3.1.38",
-        "@php-wasm/xdebug-bridge": "3.1.38",
-        "@wp-playground/blueprints": "3.1.38",
-        "@wp-playground/common": "3.1.38",
-        "@wp-playground/storage": "3.1.38",
-        "@wp-playground/tools": "3.1.38",
-        "@wp-playground/wordpress": "3.1.38",
+        "@php-wasm/cli-util": "3.1.45",
+        "@php-wasm/logger": "3.1.45",
+        "@php-wasm/node": "3.1.45",
+        "@php-wasm/progress": "3.1.45",
+        "@php-wasm/universal": "3.1.45",
+        "@php-wasm/util": "3.1.45",
+        "@php-wasm/xdebug-bridge": "3.1.45",
+        "@wp-playground/blueprints": "3.1.45",
+        "@wp-playground/common": "3.1.45",
+        "@wp-playground/storage": "3.1.45",
+        "@wp-playground/tools": "3.1.45",
+        "@wp-playground/wordpress": "3.1.45",
         "express": "4.22.2",
         "fs-extra": "11.1.1",
         "tmp-promise": "3.0.3",
@@ -1545,15 +1586,56 @@
         "wp-playground-cli": "wp-playground.js"
       }
     },
+    "node_modules/@wp-playground/cli/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@wp-playground/cli/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wp-playground/cli/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@wp-playground/common": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.38.tgz",
-      "integrity": "sha512-v2nO0h9US0ohIOuSOeYwn8GmOkYkvoUdGAsKnRMPkmXd4zRcvduvfuhSunZXZYIkHiZc7pPawPUtuHml5oGHFQ==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.45.tgz",
+      "integrity": "sha512-dhVGdPqp4D0RhodW9sxdI3gdKPI98ue0oyXX4AeL4toLvjzKF1nz3AwniojsuHbJr0RV0QhA/Z2rYcTjynLD8A==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.38",
-        "@php-wasm/util": "3.1.38"
+        "@php-wasm/universal": "3.1.45",
+        "@php-wasm/util": "3.1.45"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1561,29 +1643,30 @@
       }
     },
     "node_modules/@wp-playground/storage": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.38.tgz",
-      "integrity": "sha512-QSDb8f5eGg2ZE6dq2hWHJHTj5kVVlPZDoCTAv5f+VE8gauBc/8FKKQgZgGPW/3t8LcSt8GLYG50Uw3B+xOwHIg==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.45.tgz",
+      "integrity": "sha512-c9iWgHHhwEElroXqWBi8B7rSsvAbSYjCDA1m5zTmg+jpscbT8zLrIohJ3WANbWljeSxG4sWA87PLqARdchyl3A==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/stream-compression": "3.1.38",
-        "@php-wasm/universal": "3.1.38",
-        "@php-wasm/util": "3.1.38",
+        "@php-wasm/stream-compression": "3.1.45",
+        "@php-wasm/universal": "3.1.45",
+        "@php-wasm/util": "3.1.45",
         "@zip.js/zip.js": "2.7.57",
         "isomorphic-git": "1.37.6",
         "octokit": "3.1.2",
-        "pako": "^1.0.10"
+        "pako": "^1.0.10",
+        "sha.js": "2.4.12"
       }
     },
     "node_modules/@wp-playground/tools": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@wp-playground/tools/-/tools-3.1.38.tgz",
-      "integrity": "sha512-teegXL7ZDC6RO2r7i0Qa9VOTGynPrDaoN300kkIgO7K8DKDNfm7lblrL1AhdKxQ4wtTavCw2uqdt2y+sUqp5IA==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@wp-playground/tools/-/tools-3.1.45.tgz",
+      "integrity": "sha512-nhGuCsVgd0VIe+nQgrKKsVXCu2XHHSnj7+GiH4qIThYUpXLMZo/s+w1bI0ANGOCgpUTOv89Q2JOFPrn37+b3tA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wp-playground/blueprints": "3.1.38"
+        "@wp-playground/blueprints": "3.1.45"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1591,16 +1674,17 @@
       }
     },
     "node_modules/@wp-playground/wordpress": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.38.tgz",
-      "integrity": "sha512-LIJPoXF68TXZxX7mUTCULFcS9enMA7zPMxoXvizZsG9ORGjFiMACeX1BsKaneZWIZjozZtZBlFwMb63+K6M5Ig==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.45.tgz",
+      "integrity": "sha512-kQqx7m4oKRnSmTxiwdwVnUGetJINHVULMURff2+JZ4EGLqAUVscyCQ4YvQMnIho6gASyzt8TYLr3GqxU+1n6AA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.38",
-        "@php-wasm/universal": "3.1.38",
-        "@php-wasm/util": "3.1.38",
-        "@wp-playground/common": "3.1.38"
+        "@php-wasm/logger": "3.1.45",
+        "@php-wasm/universal": "3.1.45",
+        "@php-wasm/util": "3.1.45",
+        "@wp-playground/common": "3.1.45",
+        "zstddec": "^0.2.0"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -1644,6 +1728,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/aggregate-error": {
@@ -1704,9 +1798,9 @@
       }
     },
     "node_modules/anynum": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
-      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
       "dev": true,
       "funding": [
         {
@@ -1792,9 +1886,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1837,9 +1931,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1878,29 +1972,12 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -2009,9 +2086,9 @@
       }
     },
     "node_modules/chardet": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2166,22 +2243,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
-      "engines": [
-        "node >= 0.8"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -2226,13 +2287,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/copy-dir/-/copy-dir-1.3.0.tgz",
       "integrity": "sha512-Q4+qBFnN4bwGwvtXXzbp4P/4iNk0MaiGAzvQ8OiMtlLjkIKjmNN689uVzShSM0908q7GoFHXIPx4zi75ocoaHw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2609,22 +2663,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/extract-zip": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
-      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "concat-stream": "^1.6.2",
-        "debug": "^2.6.9",
-        "mkdirp": "^0.5.4",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2633,9 +2671,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "dev": true,
       "funding": [
         {
@@ -2650,9 +2688,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
       "dev": true,
       "funding": [
         {
@@ -2662,14 +2700,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
-      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
       "dev": true,
       "funding": [
         {
@@ -2679,24 +2717,15 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^2.1.0",
+        "@nodable/entities": "^3.0.0",
         "fast-xml-builder": "^1.2.0",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.3.0",
-        "xml-naming": "^0.1.0"
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/finalhandler": {
@@ -3051,9 +3080,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3184,10 +3213,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3224,33 +3266,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/isomorphic-git/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/isomorphic-git/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -3268,9 +3283,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3671,19 +3686,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -3702,9 +3704,9 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
-      "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3884,9 +3886,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
       "dev": true,
       "funding": [
         {
@@ -3940,13 +3942,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/pify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -3977,13 +3972,6 @@
         "node": ">= 0.6.0"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -4010,13 +3998,14 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -4078,27 +4067,21 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
-    },
-    "node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -4216,9 +4199,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4542,21 +4525,14 @@
       }
     },
     "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
       }
-    },
-    "node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -4656,9 +4632,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
-      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
       "dev": true,
       "funding": [
         {
@@ -4668,7 +4644,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "anynum": "^1.0.0"
+        "anynum": "^1.0.1"
       }
     },
     "node_modules/supports-color": {
@@ -4719,13 +4695,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/to-buffer/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -4765,17 +4734,10 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4816,13 +4778,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -5007,9 +4962,9 @@
       }
     },
     "node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
       "dev": true,
       "funding": [
         {
@@ -5073,9 +5028,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5123,17 +5078,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
     "node_modules/yoctocolors-cjs": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
@@ -5146,6 +5090,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zstddec": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.2.0.tgz",
+      "integrity": "sha512-oyPnDa1X5c13+Y7mA/FDMNJrn4S8UNBe0KCqtDmor40Re7ALrPN6npFwyYVRRh+PqozZQdeg23QtbcamZnG5rA==",
+      "dev": true,
+      "license": "MIT AND BSD-3-Clause"
     }
   }
 }

--- a/patchwork.json
+++ b/patchwork.json
@@ -1,5 +1,6 @@
 {
   "redefinable-internals": [
+    "debug_backtrace",
     "constant",
     "realpath"
   ]

--- a/tests/unit/admin/class-admin-notices-unit-Test.php
+++ b/tests/unit/admin/class-admin-notices-unit-Test.php
@@ -59,6 +59,104 @@ class Admin_Notices_Unit_Test extends Unit_Testcase {
 	}
 
 	/**
+	 * Dismissing another plugin's WPTRT notice must not be intercepted: this class previously called
+	 * `check_admin_referer()` with its own notice's nonce action on every `wptrt_dismiss_notice` ajax
+	 * request, `die()`ing with a 403 when the request was for a different notice (whose nonce is for
+	 * that notice's own id), e.g. bh-wp-private-uploads' "directory is publicly accessible" notice.
+	 *
+	 * `check_admin_referer` is deliberately not stubbed: if the code under test called it, WP_Mock
+	 * would raise an undefined-function error.
+	 *
+	 * @covers ::admin_notices
+	 */
+	public function test_returns_early_when_ajax_dismissal_is_for_another_notice(): void {
+
+		$logger   = $this->logger;
+		$settings = $this->makeEmpty(
+			Logger_Settings_Interface::class,
+			array(
+				'get_plugin_slug' => 'test',
+			)
+		);
+		$api      = $this->makeEmpty( API_Interface::class, array() );
+
+		\WP_Mock::userFunction( 'is_admin' )->andReturnTrue();
+		\WP_Mock::userFunction( 'wp_doing_ajax' )->andReturnTrue();
+		\WP_Mock::passthruFunction( 'sanitize_key' );
+		\WP_Mock::passthruFunction( 'wp_unslash' );
+
+		// The option is only read after the ajax gate, so it must never be queried here.
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'times' => 0,
+			)
+		);
+
+		global $pagenow;
+		$pagenow = 'index.php';
+
+		$_POST['action'] = 'wptrt_dismiss_notice';
+		$_POST['id']     = 'other-plugin-private-uploads-url-is-public';
+
+		try {
+			$sut = new Admin_Notices( $api, $settings, $logger );
+
+			$sut->admin_notices();
+
+			$this->assertEmpty( $sut->get_all() );
+		} finally {
+			unset( $_POST['action'], $_POST['id'] );
+		}
+	}
+
+	/**
+	 * An ajax dismissal of this plugin's own recent-error notice proceeds past the gate (observable
+	 * because the recent-error option is then queried).
+	 *
+	 * @covers ::admin_notices
+	 */
+	public function test_proceeds_when_ajax_dismissal_is_for_own_notice(): void {
+
+		$logger   = $this->logger;
+		$settings = $this->makeEmpty(
+			Logger_Settings_Interface::class,
+			array(
+				'get_plugin_slug' => 'test',
+			)
+		);
+		$api      = $this->makeEmpty( API_Interface::class, array() );
+
+		\WP_Mock::userFunction( 'is_admin' )->andReturnTrue();
+		\WP_Mock::userFunction( 'wp_doing_ajax' )->andReturnTrue();
+		\WP_Mock::passthruFunction( 'sanitize_key' );
+		\WP_Mock::passthruFunction( 'wp_unslash' );
+
+		\WP_Mock::userFunction(
+			'get_option',
+			array(
+				'args'   => array( 'test-recent-error-data' ),
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		global $pagenow;
+		$pagenow = 'index.php';
+
+		$_POST['action'] = 'wptrt_dismiss_notice';
+		$_POST['id']     = 'test-recent-error';
+
+		try {
+			$sut = new Admin_Notices( $api, $settings, $logger );
+
+			$sut->admin_notices();
+		} finally {
+			unset( $_POST['action'], $_POST['id'] );
+		}
+	}
+
+	/**
 	 * @covers ::admin_notices
 	 */
 	public function test_return_early_when_not_in_admin_or_ajax(): void {

--- a/tests/unit/api/class-api-unit-Test.php
+++ b/tests/unit/api/class-api-unit-Test.php
@@ -152,6 +152,107 @@ EOD;
 	}
 
 	/**
+	 * The context is returned as its raw JSON string, not decoded (decoded object trees use roughly
+	 * an order of magnitude more memory, which caused out-of-memory errors on the logs page).
+	 *
+	 * @covers ::parse_log
+	 * @covers ::log_lines_to_entry
+	 */
+	public function test_parse_log_returns_context_as_json_string(): void {
+
+		$log_contents = <<<'EOD'
+2026-08-23T00:00:01+00:00 DEBUG First message
+{"key":"value"}
+2026-08-23T00:00:02+00:00 INFO Second message with no context
+EOD;
+
+		$temp_file = tempnam( sys_get_temp_dir(), 'log' ) . '.txt';
+
+		try {
+			file_put_contents( $temp_file, $log_contents );
+
+			$sut = new API( $this->makeEmpty( Logger_Settings_Interface::class ), $this->logger );
+
+			$result = $sut->parse_log( $temp_file );
+
+			$this->assertCount( 2, $result );
+			$this->assertSame( '{"key":"value"}', $result[0]['context'] );
+			$this->assertNull( $result[1]['context'] );
+		} finally {
+			unlink( $temp_file );
+		}
+	}
+
+	/**
+	 * With a max-entries limit, only the most recent entries are kept (in order), while the total
+	 * count and level counts still cover the whole file.
+	 *
+	 * @covers ::parse_log_file
+	 */
+	public function test_parse_log_file_keeps_only_the_most_recent_entries(): void {
+
+		$lines = array();
+		for ( $i = 1; $i <= 10; $i++ ) {
+			$level   = 0 === $i % 2 ? 'ERROR' : 'DEBUG';
+			$lines[] = sprintf( '2026-08-23T00:00:%02d+00:00 %s Message %d', $i, $level, $i );
+		}
+
+		$temp_file = tempnam( sys_get_temp_dir(), 'log' ) . '.txt';
+
+		try {
+			file_put_contents( $temp_file, implode( "\n", $lines ) );
+
+			$sut = new API( $this->makeEmpty( Logger_Settings_Interface::class ), $this->logger );
+
+			$result = $sut->parse_log_file( $temp_file, 3 );
+
+			$this->assertSame( 10, $result->total_entries_count );
+			$this->assertTrue( $result->is_truncated() );
+			$this->assertSame( array( 'debug' => 5, 'error' => 5 ), $result->level_counts );
+
+			$this->assertCount( 3, $result->entries );
+			$this->assertSame( 'Message 8', $result->entries[0]['message'] );
+			$this->assertSame( 'Message 9', $result->entries[1]['message'] );
+			$this->assertSame( 'Message 10', $result->entries[2]['message'] );
+		} finally {
+			unlink( $temp_file );
+		}
+	}
+
+	/**
+	 * An entry larger than the max-entry-bytes limit is cut short with a truncation note, so a single
+	 * enormous entry (e.g. a whole email in the context) cannot exhaust memory.
+	 *
+	 * @covers ::parse_log_file
+	 */
+	public function test_parse_log_file_truncates_oversized_entries(): void {
+
+		$log_contents = "2026-08-23T00:00:01+00:00 DEBUG Big entry\n"
+			. str_repeat( "Lorem ipsum dolor sit amet.\n", 100 )
+			. '2026-08-23T00:00:02+00:00 INFO Small entry';
+
+		$temp_file = tempnam( sys_get_temp_dir(), 'log' ) . '.txt';
+
+		try {
+			file_put_contents( $temp_file, $log_contents );
+
+			$sut = new API( $this->makeEmpty( Logger_Settings_Interface::class ), $this->logger );
+
+			$result = $sut->parse_log_file( $temp_file, null, 256 );
+
+			$this->assertSame( 2, $result->total_entries_count );
+
+			$big_entry_message = $result->entries[0]['message'];
+			$this->assertLessThan( 512, strlen( $big_entry_message ) );
+			$this->assertStringContainsString( 'truncated', $big_entry_message );
+
+			$this->assertSame( 'Small entry', $result->entries[1]['message'] );
+		} finally {
+			unlink( $temp_file );
+		}
+	}
+
+	/**
 	 * Parsing date in and out of int / datetime results in a one-second difference, which is fine.
 	 *
 	 * @covers ::get_last_log_time

--- a/tests/unit/api/class-parsed-log-file-unit-Test.php
+++ b/tests/unit/api/class-parsed-log-file-unit-Test.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace BrianHenryIE\WP_Logger\API;
+
+use BrianHenryIE\WP_Logger\Unit_Testcase;
+
+/**
+ * @coversDefaultClass \BrianHenryIE\WP_Logger\API\Parsed_Log_File
+ */
+class Parsed_Log_File_Unit_Test extends Unit_Testcase {
+
+	/**
+	 * @covers ::__construct
+	 * @covers ::is_truncated
+	 */
+	public function test_is_truncated_when_entries_were_omitted(): void {
+
+		$entry = array(
+			'time'     => '2026-08-23T00:00:00+00:00',
+			'datetime' => null,
+			'level'    => 'debug',
+			'message'  => 'message',
+			'context'  => null,
+		);
+
+		$complete = new Parsed_Log_File( array( $entry ), 1, array( 'debug' => 1 ) );
+		$this->assertFalse( $complete->is_truncated() );
+
+		$truncated = new Parsed_Log_File( array( $entry ), 5, array( 'debug' => 5 ) );
+		$this->assertTrue( $truncated->is_truncated() );
+	}
+}

--- a/tests/unit/private-uploads/class-url-is-public-unit-Test.php
+++ b/tests/unit/private-uploads/class-url-is-public-unit-Test.php
@@ -14,15 +14,45 @@ class URL_Is_Public_Unit_Test extends Unit_Testcase {
 	/**
 	 * @covers ::change_warning_message
 	 */
-	public function test_message_changed(): void {
+	public function test_message_changed_for_own_private_uploads_instance(): void {
 
-		$sut = new URL_Is_Public();
+		$settings = $this->makeEmpty(
+			Logger_Settings_Interface::class,
+			array(
+				'get_plugin_slug' => 'plugin-slug',
+			)
+		);
+
+		$sut = new URL_Is_Public( $settings );
 
 		$message = 'Unused';
 		$url     = 'https://example.com/wp-content/logs';
 
-		$result = $sut->change_warning_message( $message, $url );
+		$result = $sut->change_warning_message( $message, 'plugin-slug_logger', 'plugin-slug_private', $url );
 
 		$this->assertStringContainsString( 'Please update your webserver configuration', $result );
+	}
+
+	/**
+	 * The filter fires for every private-uploads instance; other instances' messages must be unchanged.
+	 *
+	 * @covers ::change_warning_message
+	 */
+	public function test_message_unchanged_for_other_private_uploads_instances(): void {
+
+		$settings = $this->makeEmpty(
+			Logger_Settings_Interface::class,
+			array(
+				'get_plugin_slug' => 'plugin-slug',
+			)
+		);
+
+		$sut = new URL_Is_Public( $settings );
+
+		$message = 'Another plugin instance message';
+
+		$result = $sut->change_warning_message( $message, 'other-plugin', 'other_plugin_private', 'https://example.com/wp-content/uploads/other' );
+
+		$this->assertSame( $message, $result );
 	}
 }

--- a/tests/unit/wp-includes/class-plugin-logger-actions-unit-Test.php
+++ b/tests/unit/wp-includes/class-plugin-logger-actions-unit-Test.php
@@ -178,10 +178,10 @@ class Plugin_Logger_Actions_Unit_Test extends Unit_Testcase {
 	public function test_add_private_uploads_hooks(): void {
 
 		\WP_Mock::expectFilterAdded(
-			'bh_wp_private_uploads_url_is_public_warning_plugin-slug_logger',
+			'bh_wp_private_uploads_url_is_public_warning',
 			array( \WP_Mock\Functions::type( URL_Is_Public::class ), 'change_warning_message' ),
 			10,
-			2
+			4
 		);
 
 		$api      = $this->makeEmpty( API_Interface::class );

--- a/tests/wpunit/api/class-bh-wp-psr-logger-wpunit-Test.php
+++ b/tests/wpunit/api/class-bh-wp-psr-logger-wpunit-Test.php
@@ -88,9 +88,9 @@ class BH_WP_PSR_Logger_WPUnit_Test extends WPUnit_Testcase {
 		 */
 		add_filter(
 			'plugin-slug_bh_wp_logger_log',
-			fn( array $log_data, $settings, $bh_wp_psr_logger ) => null,
+			fn( array $log_data, string $plugin_slug, $settings, $bh_wp_psr_logger ) => null,
 			10,
-			3
+			4
 		);
 
 		$sut->log( LogLevel::ERROR, 'Trying to access array offset on value of type bool', $context );
@@ -155,10 +155,10 @@ class BH_WP_PSR_Logger_WPUnit_Test extends WPUnit_Testcase {
 
 		add_filter(
 			'plugin-slug_bh_wp_logger_log',
-			fn( array $log_data, $settings, $bh_wp_psr_logger )
+			fn( array $log_data, string $plugin_slug, $settings, $bh_wp_psr_logger )
 				=> 'cancel me' === $log_data['message'] ? null : $log_data,
 			10,
-			3
+			4
 		);
 
 		$sut->info( 'cancel me' ); // Cancelled: early return inside try; finally resets is_looping.


### PR DESCRIPTION
This branch carries the PHP 8.1 / bh-wp-private-uploads update plus three fixes and a hook-signature change made along the way:

## Pre-existing branch topic
- Require PHP 8.1; update `bh-wp-private-uploads` to >0.4.0; remove the build-assets step.

## Fix: out-of-memory error viewing large log files (`c29140f`)
A 105MB log file peaked at 863MB parsing (the page parsed the file twice and decoded every entry's JSON context into stdClass trees), fataling under a 128M limit. New `API::parse_log_file( $filepath, $max_entries, $max_entry_bytes )` streams the file once, keeps the most recent 1,000 entries in a ring buffer (64KB cap each, with a truncation note), and returns a `Parsed_Log_File` with full-file entry/level counts. Entry `context` is now the raw JSON string, decoded per-row for display. Peak memory on the same file: 863MB → 95MB. Also fixes `menu_page_url()` returning `''` in admin-post redirects and the download link using the wrong date.

## Fix: 403 dismissing other plugins' WPTRT admin notices (`39eaca4`)
The recent-error notice's ajax gate called `check_admin_referer()` on every `wptrt_dismiss_notice` request, `die()`ing with a 403 when the dismissal targeted a different plugin's notice (e.g. bh-wp-private-uploads' "publicly accessible" warning). It now gates on the posted notice id and leaves nonce verification to the WPTRT Dismiss handler.

## Breaking: `$plugin_slug` passed after the filtered value in library filters (`e947498`)
- `{$plugin_slug}_bh_wp_logger_log`: `( $log_data, $plugin_slug, $settings, $bh_wp_psr_logger )`
- `{$plugin_slug}_bh_wp_logger_column`: `( $column_output, $plugin_slug, $item, $column_name, $settings, $bh_wp_psr_logger )`

Also fixes the custom "logs directory is publicly accessible" message, which was hooked on a stale pre-0.4.0 private-uploads filter name and never applied — `URL_Is_Public` now hooks `bh_wp_private_uploads_url_is_public_warning` and matches its own instance by plugin slug.

**Merge-order note:** requires bh-wp-private-uploads with BrianHenryIE/bh-wp-private-uploads#123 (the new `url_is_public_warning` argument order).

Tests: unit 57 ✓, wpunit 28 ✓; phpcs clean; phpstan at the pre-existing baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)